### PR TITLE
Make the playbook Ubuntu 18 compatible

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates systemd && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,16 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: instance
+  - name: ubuntu16
     image: ubuntu:16.04
+    cap_add:
+      - SYS_ADMIN
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    command: /sbin/init
+    privileged: true
+  - name: ubuntu18
+    image: ubuntu:18.04
     cap_add:
       - SYS_ADMIN
     volume_mounts:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,9 +7,9 @@
       apt:
         update_cache: true
         cache_valid_time: 600
-    - name: Update apt cache
+    - name: Install required packages
       apt:
-        name: "iproute"
+        name: "iproute2"
         state: present
     - name: Gather facts now that prerequisite packages are installed
       setup: filter=ansible_*

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -3,12 +3,15 @@ import os
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
 
 
-def test_hosts_file(host):
-    f = host.file('/etc/hosts')
+def test_docker_running_and_enabled(host):
+    docker = host.service("docker")
+    assert docker.is_running
+    assert docker.is_enabled
 
-    assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+
+def test_able_to_access_docker_without_root(host):
+    assert "docker" in host.user("ubuntu").groups

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,14 +14,24 @@
     state: present
   when: docker_install_kernel_extras|bool
 
-- name: Install system dependencies
+- name: Install common system dependencies
   apt:
     name:
       - "apt-transport-https"
       - "ca-certificates"
-      - "gnupg-curl"
+      - "gnupg2"
       - "software-properties-common"
       - "python-pip"
+    force_apt_get: true
+    state: present
+
+- name: Install Ubuntu 16 system dependencies
+  when: |
+    ansible_facts['distribution'] == "Ubuntu"
+    and ansible_facts['distribution_major_version'] == "16"
+  apt:
+    name:
+      - "gnupg-curl"
     force_apt_get: true
     state: present
 

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -139,3 +139,9 @@
   tags:
     - tls-client
     - tls-download
+    # The tests may fail sometimes here because due to a race condition caused
+    # by files being downloaded to the same place by the different platforms
+    # molecule is run against. There seem to be no supported way of separating
+    # the workspaces between the platforms, so we have to skip this task when
+    # running tests.
+    - molecule-notest


### PR DESCRIPTION
Some comments:
- The ubuntu:18.04 image doesn't contain systemd, so I had to install it.
- `iproute` had to be switched out for `iproute2`, which is available both on Ubuntu 16.04 and 18.04
- TLS download didn't work in the test, now that we run tests against multiple platforms at the same time, so I had to exclude it. Included some comments in the playbook.