### PR TITLE
Multi node support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install testinfra molecule docker
 
 script:
-  - molecule --debug test
+  - travis_wait molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install testinfra molecule docker
 
 script:
-  - travis_wait molecule test
+  - travis_wait 30 molecule test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ```yaml
 - src: https://github.com/5monkeys/ansible-docker-role
   name: docker
-``` 
+```
 
 * Update `ansible.cfg` to search for roles relative to playbook:
 
@@ -51,7 +51,7 @@ docker_use_tls: true
 docker_tls_organization: "Acme"
 # Where to place certificates on host
 docker_tls_path: "/etc/docker/certs"
-# When the client certificate should expire. 
+# When the client certificate should expire.
 docker_tls_client_expires_after: "+52w"
 # The client certificate common name
 docker_tls_client_common_name: "client"
@@ -60,12 +60,49 @@ docker_tls_client_common_name: "client"
 docker_enable_swarm: true
 # What version of the python openssl library to use
 docker_py_openssl_version: "19.0.0"
+
+# These are only relevant when 'docker_enable_swarm' is true
+docker_swarm_interface: "{{ ansible_default_ipv4['interface'] }}"
+docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
+docker_swarm_port: 2377
+
+# No node labels set per default
+docker_swarm_labels: {}
 ```
 
-## Example playbook
+## Example playbook(s)
+
+Be aware of that both the order of the groups and targets within the
+`docker_swarm_managers` group shown below matters.
+
+The first host in the `docker_swarm_managers` group will be initiated as the master node.
+
+Any host declared in both groups will be configured as a manager and worker(or master 
+and worker if above is true).
+
+_Declaration order of the hosts groups matters_, we expect the `docker_swarm_managers`
+group to come before the `docker_swarm_workers` group in any hosts file.
+
+In order to declare a node as both worker and manager, it has to be explicitly
+declared in both `docker_swarm_managers` and `docker_swarm_workers` groups. _Unlike
+the default behaviour from docker_, where a joining manager node will perform tasks,
+if not `--availability=[drain|pause]` argument is given.
+
+### Single node setup
+
+```ini
+# hosts file
+[docker_swarm_managers]
+host1
+
+[docker_swarm_workers]
+host1
+```
+
 ```yaml
+# playbook.yml
 - name: Setup docker
-  hosts: managers
+  hosts: all
   become: true
   become_user: root
   roles:
@@ -74,4 +111,95 @@ docker_py_openssl_version: "19.0.0"
     docker_home: "{{ inventory_dir }}/.certs/"
     docker_tls_organization: "my_org"
     docker_ce_version: "18.06"
+    docker_swarm_interface: eth0
+    docker_swarm_addr: "192.168.1.100"
+    docker_swarm_port: 2377
+```
+
+### Multi node setup
+
+A multi node setup only accepts a `docker_swarm_managers` group with an **odd**
+host count. This is in line with Docker's recommendation([which you can read more
+about here](https://docs.docker.com/engine/swarm/admin_guide/)).
+
+```ini
+# hosts file
+[docker_swarm_managers]
+manager1  # <-- Will be initiated as master node
+manager2
+manager3
+
+[docker_swarm_workers]
+worker1
+worker2
+manager3  # <-- A manager node accepting tasks
+```
+
+```yaml
+# playbook.yml
+- name: Setup docker swarm
+  hosts: all
+  become: true
+  become_user: root
+  roles:
+    - docker
+  vars:
+    docker_home: "{{ inventory_dir }}/.certs/"
+    docker_tls_organization: "my_org"
+    docker_ce_version: "18.06"
+    docker_enable_swarm: true
+```
+
+## Adding labels to swarm nodes
+
+The playbook looks for a declared variable named `docker_swarm_labels` in order
+to set swarm labels on a node.
+
+`docker_swarm_labels` is expected to be defined as a dict.
+
+For a given host, the value of the `docker_swarm_labels` variable will replace
+_all_ of the node's current labels. As so; if a node had previously defined any
+labels, running your playbook again but now with an undefined or empty
+`docker_swarm_labels` variable would remove _all_ labels from that node.
+
+```yml
+# playbook.yml
+- name: Setup docker swarm
+  hosts: all
+  become: true
+  become_user: root
+  roles:
+    - docker
+  vars:
+    docker_swarm_labels:
+      all_nodes: gets_this_label
+```
+
+## Converting "manager and worker" node to "manager only" node
+
+Converting an already deployed "manager and worker" node to a "manager only" node
+is done by removing the node from the `docker_swarm_workers` group.
+
+Consider an initial deploy with a hosts file like:
+
+```ini
+# hosts file
+[docker_swarm_managers]
+host1
+
+[docker_swarm_workers]
+host1
+worker1
+```
+
+Now changing hosts to what follows and then running your playbook again would set
+the node as "manager only":
+
+```ini
+# hosts file
+[docker_swarm_managers]
+host1
+
+[docker_swarm_workers]
+worker1
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker_storage_driver: "overlay2"
 docker_python_version: "4.0.1"
 
 # If TLS should be enabled on the docker daemon and SSL-certificates generated
-docker_use_tls: true
+docker_use_tls: "{{ 'docker_swarm_managers' in group_names }}"
 # What to set as Organization in SSL-certificates
 docker_tls_organization: "Acme"
 # Where to place certificates on host

--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ host1
 
 [docker_swarm_workers]
 host1
+
+[nodes]
+host1
 ```
 
 ```yaml
 # playbook.yml
 - name: Setup docker
-  hosts: all
+  hosts: nodes
   become: true
   become_user: root
   roles:
@@ -133,12 +136,16 @@ manager3
 worker1
 worker2
 manager3  # <-- A manager node accepting tasks
+
+[nodes:children]
+docker_swarm_managers
+docker_swarm_workers
 ```
 
 ```yaml
 # playbook.yml
 - name: Setup docker swarm
-  hosts: all
+  hosts: nodes
   become: true
   become_user: root
   roles:
@@ -165,14 +172,14 @@ labels, running your playbook again but now with an undefined or empty
 ```yml
 # playbook.yml
 - name: Setup docker swarm
-  hosts: all
+  hosts: nodes
   become: true
   become_user: root
   roles:
     - docker
   vars:
     docker_swarm_labels:
-      all_nodes: gets_this_label
+      nodes: gets_this_label
 ```
 
 ## Converting "manager and worker" node to "manager only" node

--- a/README.md
+++ b/README.md
@@ -72,16 +72,10 @@ docker_swarm_labels: {}
 
 ## Example playbook(s)
 
-Be aware of that both the order of the groups and targets within the
-`docker_swarm_managers` group shown below matters.
-
 The first host in the `docker_swarm_managers` group will be initiated as the master node.
 
 Any host declared in both groups will be configured as a manager and worker(or master 
 and worker if above is true).
-
-_Declaration order of the hosts groups matters_, we expect the `docker_swarm_managers`
-group to come before the `docker_swarm_workers` group in any hosts file.
 
 In order to declare a node as both worker and manager, it has to be explicitly
 declared in both `docker_swarm_managers` and `docker_swarm_workers` groups. _Unlike
@@ -113,10 +107,7 @@ host1
   vars:
     docker_home: "{{ inventory_dir }}/.certs/"
     docker_tls_organization: "my_org"
-    docker_ce_version: "18.06"
-    docker_swarm_interface: eth0
-    docker_swarm_addr: "192.168.1.100"
-    docker_swarm_port: 2377
+    docker_ce_version: "5:19.03"
 ```
 
 ### Multi node setup
@@ -153,7 +144,7 @@ docker_swarm_workers
   vars:
     docker_home: "{{ inventory_dir }}/.certs/"
     docker_tls_organization: "my_org"
-    docker_ce_version: "18.06"
+    docker_ce_version: "5:19.03"
     docker_enable_swarm: true
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ docker_hosts:
 docker_storage_driver: "overlay2"
 docker_python_version: "4.0.1"
 
-docker_use_tls: true
+docker_use_tls: "{{ 'docker_swarm_managers' in group_names }}"
 docker_tls_organization: "Acme"
 docker_tls_path: "/etc/docker/certs"
 docker_tls_client_expires_after: "+52w"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,8 @@ docker_tls_client_common_name: "client"
 
 docker_enable_swarm: true
 docker_py_openssl_version: "19.0.0"
+
+# These are only relevant when 'docker_enable_swarm' is true
+docker_swarm_interface: "{{ ansible_default_ipv4['interface'] }}"
+docker_swarm_addr: "{{ hostvars[inventory_hostname]['ansible_' + docker_swarm_interface]['ipv4']['address'] }}"
+docker_swarm_port: 2377

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,6 +37,16 @@ platforms:
     groups:
       - docker_swarm_managers
       - docker_swarm_workers
+  - name: extra_manager2
+    image: ubuntu:18.04
+    cap_add:
+      - SYS_ADMIN
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker_swarm_managers
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -36,6 +36,7 @@ platforms:
     privileged: true
     groups:
       - docker_swarm_managers
+      - docker_swarm_workers
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,6 +14,8 @@ platforms:
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     command: /sbin/init
     privileged: true
+    groups:
+      - docker_swarm_managers
   - name: ubuntu18
     image: ubuntu:18.04
     cap_add:
@@ -22,6 +24,18 @@ platforms:
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     command: /sbin/init
     privileged: true
+    groups:
+      - docker_swarm_workers
+  - name: extra_manager
+    image: ubuntu:18.04
+    cap_add:
+      - SYS_ADMIN
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker_swarm_managers
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -41,6 +41,16 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+  inventory:
+    host_vars:
+      ubuntu16:
+        docker_swarm_labels:
+          one: manager
+          second: label
+    group_vars:
+      docker_swarm_workers:
+        docker_swarm_labels:
+          a: worker
 scenario:
   name: default
 verifier:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -90,3 +90,57 @@ def test_docker_swarm_labels(host):
         assert get_labels("ubuntu18") == {"a": "worker"}
         assert get_labels("extra_manager") == {"a": "worker"}
         assert get_labels("extra_manager2") == {}
+
+
+def test_docker_daemon_json(host):
+    def parse_daemon_json():
+        filepath = "/etc/docker/daemon.json"
+        return json.loads(host.file(filepath).content_string)
+
+    hostname = host.check_output("hostname -s")
+    if hostname in runner.get_hosts("docker_swarm_managers"):
+        daemon_json = parse_daemon_json()
+        assert "hosts" in daemon_json
+        assert "storage-driver" in daemon_json
+        assert "tlsverify" in daemon_json and daemon_json["tlsverify"]
+        assert "tlscacert" in daemon_json
+        assert "tlscert" in daemon_json
+        assert "tlskey" in daemon_json
+
+    elif hostname in runner.get_hosts("docker_swarm_workers"):
+        daemon_json = parse_daemon_json()
+        assert "hosts" in daemon_json
+        assert "storage-driver" in daemon_json
+        assert "tlsverify" not in daemon_json
+        assert "tlscacert" not in daemon_json
+        assert "tlscert" not in daemon_json
+        assert "tlskey" not in daemon_json
+
+    else:
+        assert False, "Unexpected hostname in swarm setup: %s" % hostname
+
+
+def test_docker_swarm_certificates(host):
+    hostname = host.check_output("hostname -s")
+    if hostname in runner.get_hosts("docker_swarm_managers"):
+        certdir = host.file("/etc/docker/certs/")
+        assert certdir.exists
+        assert certdir.is_directory
+        certs = {
+            "ca-key.pem",
+            "ca.csr",
+            "ca.pem",
+            "server-key.pem",
+            "server.csr",
+            "server-cert.pem",
+            "key.pem",
+            "cert.pem",
+        }
+        for cert in certs:
+            certfile = host.file("/etc/docker/certs/{}".format(cert))
+            assert certfile.exists
+            assert certfile.is_file
+    elif hostname in runner.get_hosts("docker_swarm_workers"):
+        assert not host.file("/etc/docker/certs/").exists
+    else:
+        assert False, "Unexpected hostname in swarm setup: %s" % hostname

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -51,6 +51,8 @@ def test_docker_manager_node_availability(host):
 
     def get_node_info():
         cmd = "docker node inspect self --format '{{json .Spec}}'"
+        # Raises an AssertionError based on the return code of
+        # given command
         return json.loads(host.check_output(cmd))
 
     if hostname == "ubuntu18":

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -37,8 +37,8 @@ def test_docker_swarm_status(host):
     if hostname in runner.get_hosts("docker_swarm_managers"):
         msg = "Expected '%s' to be a manager" % hostname
         assert swarm_info["ControlAvailable"], msg
-        assert swarm_info["Managers"] == 2
-        assert swarm_info["Nodes"] == 3
+        assert swarm_info["Managers"] == 3
+        assert swarm_info["Nodes"] == 4
     elif hostname in runner.get_hosts("docker_swarm_workers"):
         msg = "Expected '%s' to be a worker" % hostname
         assert not swarm_info["ControlAvailable"], msg

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -44,3 +44,16 @@ def test_docker_swarm_status(host):
         assert not swarm_info["ControlAvailable"], msg
     else:
         assert False, "Unexpected hostname in swarm setup: %s" % hostname
+
+
+def test_docker_swarm_labels(host):
+    def get_labels(hostname):
+        cmd = "docker node inspect %s --format '{{json .Spec.Labels}}'"
+        return json.loads(host.check_output(cmd % hostname))
+
+    hostname = host.check_output("hostname -s")
+    if hostname in runner.get_hosts("docker_swarm_managers"):
+        assert get_labels("ubuntu16") == {"one": "manager", "second": "label"}
+        assert get_labels("ubuntu18") == {"a": "worker"}
+        assert get_labels("extra_manager") == {"a": "worker"}
+        assert get_labels("extra_manager2") == {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,12 @@
   tags:
     - swarm
 
+- import_tasks: swarm-labels.yml
+  when: docker_enable_swarm|bool
+  tags:
+    - swarm
+    - swarm_labels
+
 - import_tasks: configure.yml
   tags:
     - configure

--- a/tasks/swarm-labels.yml
+++ b/tasks/swarm-labels.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Assign labels to swarm nodes
+  docker_node:
+    hostname: "{{ ansible_hostname }}"
+    labels: "{{ docker_swarm_labels | default({}) }}"
+    labels_state: replace
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -1,9 +1,41 @@
 ---
 
-- name: Initialize swarm manager
+- name: Initialize swarm master
   docker_swarm:
     state: present
-    advertise_addr: "{{ ansible_eth0.ipv4.address }}"
+    advertise_addr: "{{ docker_swarm_addr }}"
+  # 'run_once' and 'delegate_to' allows us to register 'swarm' for all hosts
+  # Although this relies on declaration order of the hosts in order to work
+  # i.e. swarm master group has to come before manager/worker groups
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   register: "swarm"
   notify:
     - restart docker
+
+- name: Declare swarm master address as a fact
+  set_fact:
+    swarm_master_address: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
+
+- name: Join swarm worker nodes
+  docker_swarm:
+    state: join
+    advertise_addr: "{{ docker_swarm_addr }}"
+    listen_addr: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
+    join_token: "{{ swarm.swarm_facts.JoinTokens.Worker }}"
+    remote_addrs: ["{{ swarm_master_address }}"]
+  # Skip all managers moonlighting as workers
+  when: "'docker_swarm_workers' in group_names
+    and 'docker_swarm_managers' not in group_names"
+
+- name: Join swarm manager nodes
+  docker_swarm:
+    state: join
+    advertise_addr: "{{ docker_swarm_addr }}"
+    listen_addr: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
+    join_token: "{{ swarm.swarm_facts.JoinTokens.Manager }}"
+    remote_addrs: ["{{ swarm_master_address }}"]
+  when: "'docker_swarm_managers' in group_names
+    and inventory_hostname != groups['docker_swarm_managers'] | first"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -8,24 +8,24 @@
       number(currently: {{ groups['docker_swarm_managers'] | length }})"
     quiet: true
 
+- name: Make node addresses available via hostvars
+  set_fact:
+    master_node: "{{ groups['docker_swarm_managers'] | first }}"
+    docker_swarm_addr: "{{ docker_swarm_addr }}"
+    docker_swarm_port: "{{ docker_swarm_port }}"
+    docker_swarm_addr_full: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
+
 - name: Initialize swarm master
   docker_swarm:
     state: present
-    advertise_addr: "{{ docker_swarm_addr }}"
+    advertise_addr: "{{ hostvars[master_node]['docker_swarm_addr'] }}"
+    listen_addr: "{{ hostvars[master_node]['docker_swarm_addr_full'] }}"
   # 'run_once' and 'delegate_to' allows us to register 'swarm' for all hosts
-  # Although this relies on declaration order of the hosts in order to work
-  # i.e. swarm manager group has to come before the worker group
   run_once: true
-  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
+  delegate_to: "{{ master_node }}"
   register: "swarm"
   notify:
     - restart docker
-
-- name: Declare swarm master address as a fact
-  set_fact:
-    swarm_master_address: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
-  run_once: true
-  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
 
 - name: Join swarm worker nodes
   docker_swarm:
@@ -33,7 +33,7 @@
     advertise_addr: "{{ docker_swarm_addr }}"
     listen_addr: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
     join_token: "{{ swarm.swarm_facts.JoinTokens.Worker }}"
-    remote_addrs: ["{{ swarm_master_address }}"]
+    remote_addrs: ["{{ hostvars[master_node]['docker_swarm_addr_full'] }}"]
   # Skip all managers moonlighting as workers
   when: "'docker_swarm_workers' in group_names
     and 'docker_swarm_managers' not in group_names"
@@ -44,9 +44,8 @@
     advertise_addr: "{{ docker_swarm_addr }}"
     listen_addr: "{{ docker_swarm_addr }}:{{ docker_swarm_port }}"
     join_token: "{{ swarm.swarm_facts.JoinTokens.Manager }}"
-    remote_addrs: ["{{ swarm_master_address }}"]
-  when: "'docker_swarm_managers' in group_names
-    and inventory_hostname != groups['docker_swarm_managers'] | first"
+    remote_addrs: ["{{ hostvars[master_node]['docker_swarm_addr_full'] }}"]
+  when: "'docker_swarm_managers' in group_names and inventory_hostname != master_node"
 
 - name: Set correct node availability on managers
   docker_node:

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -14,7 +14,7 @@
     advertise_addr: "{{ docker_swarm_addr }}"
   # 'run_once' and 'delegate_to' allows us to register 'swarm' for all hosts
   # Although this relies on declaration order of the hosts in order to work
-  # i.e. swarm master group has to come before manager/worker groups
+  # i.e. swarm manager group has to come before the worker group
   run_once: true
   delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   register: "swarm"
@@ -35,8 +35,6 @@
     join_token: "{{ swarm.swarm_facts.JoinTokens.Worker }}"
     remote_addrs: ["{{ swarm_master_address }}"]
   # Skip all managers moonlighting as workers
-  # Managers already schedules tasks per default
-  #   See: https://docs.docker.com/engine/swarm/join-nodes/
   when: "'docker_swarm_workers' in group_names
     and 'docker_swarm_managers' not in group_names"
 

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Ensure number of swarm manager nodes
+  assert:
+    that:
+      - "{{ (groups['docker_swarm_managers'] | length) % 2 }} == 1 "
+    msg: "'docker_swarm_managers' has to count to an odd
+      number(currently: {{ groups['docker_swarm_managers'] | length }})"
+    quiet: true
+
 - name: Initialize swarm master
   docker_swarm:
     state: present

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -27,6 +27,8 @@
     join_token: "{{ swarm.swarm_facts.JoinTokens.Worker }}"
     remote_addrs: ["{{ swarm_master_address }}"]
   # Skip all managers moonlighting as workers
+  # Managers already schedules tasks per default
+  #   See: https://docs.docker.com/engine/swarm/join-nodes/
   when: "'docker_swarm_workers' in group_names
     and 'docker_swarm_managers' not in group_names"
 
@@ -39,3 +41,9 @@
     remote_addrs: ["{{ swarm_master_address }}"]
   when: "'docker_swarm_managers' in group_names
     and inventory_hostname != groups['docker_swarm_managers'] | first"
+
+- name: Set correct node availability on managers
+  docker_node:
+    availability: "{% if 'docker_swarm_workers' not in group_names %}drain{% else %}active{% endif %}"
+    hostname: "{{ ansible_hostname }}"
+  when: "'docker_swarm_managers' in group_names"

--- a/tasks/swarm.yml
+++ b/tasks/swarm.yml
@@ -52,3 +52,4 @@
     availability: "{% if 'docker_swarm_workers' not in group_names %}drain{% else %}active{% endif %}"
     hostname: "{{ ansible_hostname }}"
   when: "'docker_swarm_managers' in group_names"
+  delegate_to: "{{ master_node }}"

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -24,6 +24,8 @@
 - name: ca-key.pem
   openssl_privatekey:
     path: "{{ docker_tls_path }}/ca-key.pem"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   register: root_cert
   notify:
     - restart docker
@@ -37,6 +39,8 @@
     common_name: "Root CA Certificate"
     organization_name: "{{ docker_tls_organization }}"
     basic_constraints: "CA:TRUE"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   notify:
     - restart docker
   tags:
@@ -48,6 +52,8 @@
     privatekey_path: "{{ docker_tls_path }}/ca-key.pem"
     csr_path: "{{ docker_tls_path }}/ca.csr"
     provider: selfsigned
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   notify:
     - restart docker
   tags:
@@ -56,6 +62,8 @@
 - name: server-key.pem
   openssl_privatekey:
     path: "{{ docker_tls_path }}/server-key.pem"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   notify:
     - restart docker
   tags:
@@ -72,6 +80,8 @@
       - "IP:{{ ansible_eth0.ipv4.address }}"
       - "IP:127.0.0.1"
       - "DNS:localhost"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   notify:
     - restart docker
   tags:
@@ -84,6 +94,8 @@
     provider: ownca
     ownca_path: "{{ docker_tls_path }}/ca.pem"
     ownca_privatekey_path: "{{ docker_tls_path }}/ca-key.pem"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   notify:
     - restart docker
   tags:
@@ -102,7 +114,10 @@
 - name: key.pem
   openssl_privatekey:
     path: "{{ docker_tls_path }}/key.pem"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   tags:
+    - tls-server
     - tls-client
 
 - name: client.csr
@@ -113,6 +128,8 @@
     common_name: "{{ docker_tls_client_common_name }}"
     extendedKeyUsage:
       - "clientAuth"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   tags:
     - tls-server
 
@@ -124,14 +141,47 @@
     ownca_path: "{{ docker_tls_path }}/ca.pem"
     ownca_privatekey_path: "{{ docker_tls_path }}/ca-key.pem"
     ownca_not_after: "{{ docker_tls_client_expires_after|default(omit) }}"
+  run_once: true
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
   tags:
+    - tls-server
     - tls-client
+
+- name: Read server certificates
+  slurp:
+    src: "{{ docker_tls_path }}/{{ item }}"
+  with_items:
+    - ca-key.pem
+    - ca.csr
+    - ca.pem
+    - server-key.pem
+    - server.csr
+    - server-cert.pem
+    - key.pem
+    - cert.pem
+  register: certs
+  delegate_to: "{{ groups['docker_swarm_managers'] | first }}"
+  run_once: true
+  tags:
+    - tls-server
+
+- name: Pass server certificates to manager nodes
+  copy:
+    content: "{{ item.content | b64decode }}"
+    dest: "{{ item.source }}"
+  loop: "{{ certs.results }}"
+  loop_control:
+    label: "{{ item.source }}"
+  when: "inventory_hostname in groups['docker_swarm_managers'][1:]"
+  tags:
+    - tls-server
 
 - name: Download client certificates
   fetch:
     src: "{{ docker_tls_path }}/{{ item }}"
     dest: "{{ docker_home }}"
     flat: true
+  when: "inventory_hostname == (groups['docker_swarm_managers'] | first)"
   with_items:
     - ca.pem
     - key.pem
@@ -139,9 +189,3 @@
   tags:
     - tls-client
     - tls-download
-    # The tests may fail sometimes here because due to a race condition caused
-    # by files being downloaded to the same place by the different platforms
-    # molecule is run against. There seem to be no supported way of separating
-    # the workspaces between the platforms, so we have to skip this task when
-    # running tests.
-    - molecule-notest


### PR DESCRIPTION
## Backwards compatibility

The changes here are not backwards compatible in the (odd?) case of previously having had this playbook run on multiple hosts.
We'd now expect a hosts file to refer to any nodes involved in a _single_ swarm.

Backwards compatibility can be achieved, when above is false, by declaring any hosts deployed with the previous version under both `docker_swarm_managers` and `docker_swarm_workers`:

e.g.

Previous hosts file:
```
[managers]
host1
```

New hosts file:

```
[managers]
host1

[docker_swarm_managers]
host1

[docker_swarm_workers]
host1
```

As far as I see, it should only be necessary to change the hosts file.

## Additional info

- The swarm.yml task set asserts that there's an _odd_ number of managers declared in the `docker_swarm_managers` group.

- Node labels can be declared via the `docker_swarm_labels` (per host/group/etc) if wanted

- Three new (default) variables: `docker_swarm_interface`, `docker_swarm_addr` and `docker_swarm_port` have been added

- Would it be overkill to add a guard that validates that the worker group is non empty if all managers are declared as "manager only" nodes?

## Some drawbacks

### Demoting a manager node

As far as I could dig, I found no reasonable task/steps to let the playbook demote a manager (i.e. removing host from the manager group while having it in the worker group). Although handling that here could be quite an edge case, or perhaps at most a nice to have.

As of now, one could rearrange the hosts file so that the host only appears in the worker group and then _manually_ run `docker node demote NODE` on the manager node to sync the swarm with the hosts file layout.

### hosts groups declaration order

~As some steps are run with flags `run_once` and `delegate_to` we expect the `docker_swarm_managers` group to be declared before the `docker_swarm_workers` group. Otherwise I suspect that a `register` variable is undefined and stuff crashes.~

~At least that's what I could find online. I haven't actually tested with a real hosts file just yet.~

~**We should really test if this assumption is correct, would be nice if it isn't.**~

**EDIT: This should no longer be an issue. See changes in: a9164fd for how it was resolved. Worth noting is also that the playbook with those fixes has been tested with a multi node setup (1 worker node, 1 manager only node) where the worker group appeared before the manager group in the hosts file**