### PR TITLE
Update lint style to molecule v3

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,5 @@
+---
+
 extends: default
 
 ignore: |

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates systemd && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates systemd python3-setuptools python3-pip && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,10 +1,13 @@
 ---
+
 dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: ubuntu16
     image: ubuntu:16.04
@@ -22,14 +25,3 @@ platforms:
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     command: /sbin/init
     privileged: true
-
-provisioner:
-  name: ansible
-  lint:
-    name: ansible-lint
-scenario:
-  name: default
-verifier:
-  name: testinfra
-  lint:
-    name: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-ansible==2.8.2
+ansible==2.8.8
 ansible-lint==4.1.0
 pyOpenSSL==19.0.0
 yamllint==1.15.0
+flake8==3.7.9


### PR DESCRIPTION
Lint style has changed in v3 https://molecule.readthedocs.io/en/latest/configuration.html#lint

This also updates to `ansible==2.8.8`